### PR TITLE
fixed RuntimeError when max target is set to "max" by expanding dimen…

### DIFF
--- a/crp/concepts.py
+++ b/crp/concepts.py
@@ -100,7 +100,7 @@ class ChannelConcept(Concept):
 
         # channel maximization target
         if max_target == "sum":
-            rel_l = torch.sum(rel_l, dim=-1)
+            rel_l = torch.sum(relevance.view(*relevance.shape[:2], -1), dim=-1)
 
         elif max_target == "max":
             rel_l = torch.gather(rel_l, -1, rf_neuron.unsqueeze(-1)).squeeze(-1)

--- a/crp/concepts.py
+++ b/crp/concepts.py
@@ -100,11 +100,10 @@ class ChannelConcept(Concept):
 
         # channel maximization target
         if max_target == "sum":
-
-            rel_l = torch.sum(relevance.view(*relevance.shape[:2], -1), dim=-1)
+            rel_l = torch.sum(rel_l, dim=-1)
 
         elif max_target == "max":
-            rel_l = torch.gather(rel_l, 0, rf_neuron)
+            rel_l = torch.gather(rel_l, 2, rf_neuron.unsqueeze(2)).squeeze(2)
 
         else:
             raise ValueError("<max_target> supports only 'max' or 'sum'.")

--- a/crp/concepts.py
+++ b/crp/concepts.py
@@ -103,7 +103,7 @@ class ChannelConcept(Concept):
             rel_l = torch.sum(rel_l, dim=-1)
 
         elif max_target == "max":
-            rel_l = torch.gather(rel_l, 2, rf_neuron.unsqueeze(2)).squeeze(2)
+            rel_l = torch.gather(rel_l, -1, rf_neuron.unsqueeze(-1)).squeeze(-1)
 
         else:
             raise ValueError("<max_target> supports only 'max' or 'sum'.")


### PR DESCRIPTION
fixes #3 
setting the maximization target to "max" when performing the "run" method of FeatureVisualization results in a RuntimeError,
as rel_l has shape (batch_size, channel_number, neurons_number) and rf_neuron has shape (batch_size, channel_number).

This could be fixed by first expanding the dimensions of rf_neuron and thereafter reducing the dimension again.
And further, by setting the dimension about which to gather to the 2nd dimension.
```
rel_l = torch.gather(rel_l, 2, rf_neuron.unsqueeze(2)).squeeze(2)
```

I also replaced "relevance.view(*relevance.shape[:2], -1)" by "rel_l" as it is identical and might be easier to read.