### PR TITLE
fix: target list to numpy array for multi-target datasets

### DIFF
--- a/crp/visualization.py
+++ b/crp/visualization.py
@@ -131,6 +131,7 @@ class FeatureVisualization:
                 # TODO: test stack
                 data_broadcast = torch.stack(data_broadcast, dim=0)
                 sample_indices = np.array(sample_indices)
+                targets = np.array(targets)
 
             except NotImplementedError:
                 data_broadcast, targets, sample_indices = data_batch, targets_samples, samples_batch


### PR DESCRIPTION
Fixes #5 where the list **targets** needs to be a numpy array. This is correct for single-target datasets, where the conversion from List to NumPy array takes place in line 118 of ".../crp/visualization.py", but it was missing for multi-target datasets.