### PR TITLE
Sorting targets

### DIFF
--- a/crp/maximization.py
+++ b/crp/maximization.py
@@ -42,17 +42,17 @@ class Maximization:
 
     def analyze_layer(self, rel, concept: Concept, layer_name: str, data_indices):
 
-        d_c_sorted, rel_c_sorted, rf_c_sorted = concept.reference_sampling(
+        argsort, rel_c_sorted, rf_c_sorted = concept.reference_sampling(
             rel, layer_name, self.max_target, self.abs_norm)
         # convert batch index to dataset wide index
-        data_indices = torch.from_numpy(data_indices).to(d_c_sorted)
-        d_c_sorted = torch.take(data_indices, d_c_sorted)
+        data_indices = torch.from_numpy(data_indices).to(argsort)
+        d_c_sorted = torch.take(data_indices, argsort)
 
         SZ = self.SAMPLE_SIZE
         self.concatenate_with_results(layer_name, d_c_sorted[:SZ], rel_c_sorted[:SZ], rf_c_sorted[:SZ])
         self.sort_result_array(layer_name)
 
-        return d_c_sorted, rel_c_sorted, rf_c_sorted
+        return d_c_sorted, rel_c_sorted, rf_c_sorted, argsort
 
     def delete_result_arrays(self):
 

--- a/crp/maximization.py
+++ b/crp/maximization.py
@@ -38,21 +38,23 @@ class Maximization:
         # TODO: what happens if rf_c_sorted is empty? In sort and save
         # TODO: activation in save path instead of relevance!
         # TODO: for statistics in other class: make dummy variable for extra datset instead of SDS
-        # TODO: how preprocessing?
 
-    def analyze_layer(self, rel, concept: Concept, layer_name: str, data_indices):
+    def analyze_layer(self, rel, concept: Concept, layer_name: str, data_indices, targets):
 
-        argsort, rel_c_sorted, rf_c_sorted = concept.reference_sampling(
+        b_c_sorted, rel_c_sorted, rf_c_sorted = concept.reference_sampling(
             rel, layer_name, self.max_target, self.abs_norm)
         # convert batch index to dataset wide index
-        data_indices = torch.from_numpy(data_indices).to(argsort)
-        d_c_sorted = torch.take(data_indices, argsort)
+        data_indices = torch.from_numpy(data_indices).to(b_c_sorted)
+        d_c_sorted = torch.take(data_indices, b_c_sorted)
+        # sort targets
+        targets = torch.Tensor(targets).to(b_c_sorted)
+        t_c_sorted = torch.take(targets, b_c_sorted)
 
         SZ = self.SAMPLE_SIZE
         self.concatenate_with_results(layer_name, d_c_sorted[:SZ], rel_c_sorted[:SZ], rf_c_sorted[:SZ])
         self.sort_result_array(layer_name)
 
-        return d_c_sorted, rel_c_sorted, rf_c_sorted, argsort
+        return d_c_sorted, rel_c_sorted, rf_c_sorted, t_c_sorted
 
     def delete_result_arrays(self):
 

--- a/crp/statistics.py
+++ b/crp/statistics.py
@@ -34,19 +34,22 @@ class Statistics:
         # TODO: for statistics in other class: make dummy variable for extra datset instead of SDS
         # TODO: how preprocessing?
 
-    def analyze_layer(self, d_c_sorted, rel_c_sorted, rf_c_sorted, layer_name, targets):
-        t_unique = torch.unique(targets)
+    def analyze_layer(self, d_c_sorted, rel_c_sorted, rf_c_sorted, t_c_sorted, layer_name):
+        
+        t_unique = torch.unique(t_c_sorted)
 
         for t in t_unique:
-            t_indices = targets.t() == t
-            num_channels = targets.shape[1]
+            t_indices = t_c_sorted.t() == t
 
-            d_c_t = d_c_sorted.t()[t_indices].view(num_channels, -1).t()
-            rel_c_t = rel_c_sorted.t()[t_indices].view(num_channels, -1).t()
-            rf_c_t = rf_c_sorted.t()[t_indices].view(num_channels, -1).t()
+            #TODO: simplify
+            n_concepts = t_c_sorted.shape[1]
 
-            self.concatenate_with_results(layer_name, int(t), d_c_t, rel_c_t, rf_c_t)
-            self.sort_result_array(layer_name, int(t))
+            d_c_t = d_c_sorted.t()[t_indices].view(n_concepts, -1).t()
+            rel_c_t = rel_c_sorted.t()[t_indices].view(n_concepts, -1).t()
+            rf_c_t = rf_c_sorted.t()[t_indices].view(n_concepts, -1).t()
+
+            self.concatenate_with_results(layer_name, t.item(), d_c_t, rel_c_t, rf_c_t)
+            self.sort_result_array(layer_name, t.item())
 
     def delete_result_arrays(self):
 

--- a/crp/statistics.py
+++ b/crp/statistics.py
@@ -29,19 +29,22 @@ class Statistics:
         self.PATH = Path(path) / self.sub_folder if path else self.sub_folder
 
         self.PATH.mkdir(parents=True, exist_ok=True)
-        # TODO: what happens if rf_c_sorted is empty? In sort and save
+        # TODO: what happens if rf_c_sorted is empty? In sort and save method
         # TODO: activation in save path instead of relevance!
-        # TODO: for statistics in other class: make dummy variable for extra datset instead of SDS
-        # TODO: how preprocessing?
 
     def analyze_layer(self, d_c_sorted, rel_c_sorted, rf_c_sorted, t_c_sorted, layer_name):
         
         t_unique = torch.unique(t_c_sorted)
 
         for t in t_unique:
-            t_indices = t_c_sorted.t() == t
 
-            #TODO: simplify
+            # gather d_c, rel_c and rf_c for each target separately 
+            t_indices = t_c_sorted.t() == t
+            
+            # - each column of t_c_sorted contains the same number of same value targets
+            # - C-style arrays start indexing row-wise
+            # - we transpose, so that reshaping the flattened array, that results of [t_indices] operation,
+            #   maintains the order of elements
             n_concepts = t_c_sorted.shape[1]
 
             d_c_t = d_c_sorted.t()[t_indices].view(n_concepts, -1).t()

--- a/crp/statistics.py
+++ b/crp/statistics.py
@@ -35,18 +35,18 @@ class Statistics:
         # TODO: how preprocessing?
 
     def analyze_layer(self, d_c_sorted, rel_c_sorted, rf_c_sorted, layer_name, targets):
+        t_unique = torch.unique(targets)
 
-        t_unique = np.unique(targets)
         for t in t_unique:
+            t_indices = targets.t() == t
+            num_channels = targets.shape[1]
 
-            t_indices = np.where(targets == t)[0]
+            d_c_t = d_c_sorted.t()[t_indices].view(num_channels, -1).t()
+            rel_c_t = rel_c_sorted.t()[t_indices].view(num_channels, -1).t()
+            rf_c_t = rf_c_sorted.t()[t_indices].view(num_channels, -1).t()
 
-            d_c_t = d_c_sorted[t_indices]
-            rel_c_t = rel_c_sorted[t_indices]
-            rf_c_t = rf_c_sorted[t_indices]
-
-            self.concatenate_with_results(layer_name, t, d_c_t, rel_c_t, rf_c_t)
-            self.sort_result_array(layer_name, t)
+            self.concatenate_with_results(layer_name, int(t), d_c_t, rel_c_t, rf_c_t)
+            self.sort_result_array(layer_name, int(t))
 
     def delete_result_arrays(self):
 

--- a/crp/visualization.py
+++ b/crp/visualization.py
@@ -131,6 +131,7 @@ class FeatureVisualization:
                 # TODO: test stack
                 data_broadcast = torch.stack(data_broadcast, dim=0)
                 sample_indices = np.array(sample_indices)
+                targets = np.array(targets)
 
             except NotImplementedError:
                 data_broadcast, targets, sample_indices = data_batch, targets_samples, samples_batch
@@ -162,12 +163,10 @@ class FeatureVisualization:
         """
         Finds input samples that maximally activate each neuron in a layer and most relevant samples
         """
-        # TODO: dummy target for extra dataset
-        d_c_sorted, rel_c_sorted, rf_c_sorted, argsort = self.RelMax.analyze_layer(
-            rel, concept, layer_name, data_indices)
+        d_c_sorted, rel_c_sorted, rf_c_sorted, t_c_sorted = self.RelMax.analyze_layer(
+            rel, concept, layer_name, data_indices, targets)
 
-        targets = torch.take(torch.Tensor(targets).to(argsort), argsort)
-        self.RelStats.analyze_layer(d_c_sorted, rel_c_sorted, rf_c_sorted, layer_name, targets)
+        self.RelStats.analyze_layer(d_c_sorted, rel_c_sorted, rf_c_sorted, t_c_sorted, layer_name)
 
     @torch.no_grad()
     def analyze_activation(self, act, layer_name, concept, data_indices, targets):
@@ -181,11 +180,10 @@ class FeatureVisualization:
         act = act[unique_indices]
         targets = targets[unique_indices]
 
-        d_c_sorted, act_c_sorted, rf_c_sorted, argsort = self.ActMax.analyze_layer(
-            act, concept, layer_name, data_indices)
+        d_c_sorted, act_c_sorted, rf_c_sorted, t_c_sorted = self.ActMax.analyze_layer(
+            act, concept, layer_name, data_indices, targets)
 
-        targets = torch.take(torch.Tensor(targets).to(argsort), argsort)
-        self.ActStats.analyze_layer(d_c_sorted, act_c_sorted, rf_c_sorted, layer_name, targets)
+        self.ActStats.analyze_layer(d_c_sorted, act_c_sorted, rf_c_sorted, t_c_sorted, layer_name)
 
     def _save_results(self, d_index=None):
 

--- a/crp/visualization.py
+++ b/crp/visualization.py
@@ -163,8 +163,10 @@ class FeatureVisualization:
         Finds input samples that maximally activate each neuron in a layer and most relevant samples
         """
         # TODO: dummy target for extra dataset
-        d_c_sorted, rel_c_sorted, rf_c_sorted = self.RelMax.analyze_layer(rel, concept, layer_name, data_indices)
+        d_c_sorted, rel_c_sorted, rf_c_sorted, argsort = self.RelMax.analyze_layer(
+            rel, concept, layer_name, data_indices)
 
+        targets = torch.take(torch.Tensor(targets).to(argsort), argsort)
         self.RelStats.analyze_layer(d_c_sorted, rel_c_sorted, rf_c_sorted, layer_name, targets)
 
     @torch.no_grad()
@@ -179,8 +181,10 @@ class FeatureVisualization:
         act = act[unique_indices]
         targets = targets[unique_indices]
 
-        d_c_sorted, act_c_sorted, rf_c_sorted = self.ActMax.analyze_layer(act, concept, layer_name, data_indices)
+        d_c_sorted, act_c_sorted, rf_c_sorted, argsort = self.ActMax.analyze_layer(
+            act, concept, layer_name, data_indices)
 
+        targets = torch.take(torch.Tensor(targets).to(argsort), argsort)
         self.ActStats.analyze_layer(d_c_sorted, act_c_sorted, rf_c_sorted, layer_name, targets)
 
     def _save_results(self, d_index=None):


### PR DESCRIPTION
**Problem:**
- Reference Samples in Activation and Relevance Statistics are not correctly sorted, if the targets of the samples are shuffled.
- The ImageNet example in the tutorial is not affected, since this dataset returns samples in order. 

**Solution:**
- sort targets together with reference samples
- in statistics.py, a series of transpose operations is utilized to maintain proper order in indexing. This looks complicated, but is (for now) a very efficient solution since transposing only changes the stride of arrays (row- and column-major order).