### PR TITLE
To support path reading/editing in Windows System.

### DIFF
--- a/crp/maximization.py
+++ b/crp/maximization.py
@@ -111,7 +111,7 @@ class Maximization:
         pbar = tqdm(total=len(path_list), dynamic_ncols=True)
 
         for path in path_list:
-            filename = path.split("/")[-1]
+            filename = path.replace("\\","/").split("/")[-1]
             l_name = re.split(r"_[0-9]+_[0-9]+_\b", filename)[0]
 
             d_c_sorted = np.load(path + "data.npy")

--- a/crp/statistics.py
+++ b/crp/statistics.py
@@ -123,7 +123,7 @@ class Statistics:
 
         for path in path_list:
 
-            l_name, filename = path.split("/")[-2:]
+            l_name, filename = path.replace("\\","/").split("/")[-2:]
             target = filename.split("_")[0]
 
             d_c_sorted = np.load(path + "data.npy")


### PR DESCRIPTION
This is a minor modification to avoid path errors due to different ’\‘ separators when using RelMax on Windows systems.