### PR TITLE
SEO optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <img src="images/crp_logo.png" width="250"/>
-  <p>An open-source library for neural network interpretability built on <a href="https://github.com/chr5tphr/zennit">zennit</a>.<br>
+  <p>An open-source pytorch library for neural network interpretability built on <a href="https://github.com/chr5tphr/zennit">zennit</a>.<br>
   Read the paper now as part of <a href="https://www.nature.com/articles/s42256-023-00711-8">Nature Machine Intelligence</a> (Open Access)</p>
 </div>
 


### PR DESCRIPTION
@rachtibat 

When google-ing Concept Revelance Propagation pytorch this project does not appear, as pytorch is not mentioned once in the frontpage of this project.

Should be fixed by adding a "pytorch" in the project description.