### PR TITLE
Fix crash in visualisation.py when last batch size is 1

### DIFF
--- a/crp/visualization.py
+++ b/crp/visualization.py
@@ -118,7 +118,7 @@ class FeatureVisualization:
             samples_batch = samples[b * batch_size: (b + 1) * batch_size]
             data_batch, targets_samples = self.get_data_concurrently(samples_batch, preprocessing=True)
 
-            targets_samples = np.array(targets_samples)  # numpy operation needed
+            targets_samples = np.atleast_1d(targets_samples) # numpy operation needed
 
             # convert multi target to single target if user defined the method
             data_broadcast, targets, sample_indices = [], [], []


### PR DESCRIPTION
Closes #33 

Replaces` np.array()` with `np.atleast_1d()` in crp/visualisation.py.

This prevents a crash when the last batch has exactly one sample, ensuring the array remains iterable and doesn't become a 0-d scalar.